### PR TITLE
Add alloc feature to chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 resolver = "2"
 
 [dependencies]
-chrono = {version = "0.4", default-features = false, features = ["serde", "std"]}
+chrono = {version = "0.4", default-features = false, features = ["alloc", "serde", "std"]}
 futures = {version = "0.3", default-features = false}
 http = {version = "0.2", default-features = false}
 http-endpoint = "0.5"


### PR DESCRIPTION
With a fresh `cargo init` and `cargo add polyio`, compilation fails due to some deprecated/moved-to-feature logic in the `chrono` dependency.

```
error[E0599]: no method named `format` found for struct `Date` in the current scope
   --> /home/erik/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/polyio-0.13.0/src/api/aggregates.rs:116:32
    |
116 |       start = input.start_date.format("%Y-%m-%d"),
    |                                ^^^^^^ method not found in `Date<Utc>`

```
This PR adds the alloc feature so https://github.com/chronotope/chrono/blob/v0.4.40/src/date.rs#L348-L353 compiles as expected.
